### PR TITLE
Update to 1.0.17

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -7,10 +7,7 @@ set -eo pipefail
 
 ### Constants
 
-VERSION=1.0.16
-SODIUM_DIR=libsodium-$VERSION
-TARBALL=$SODIUM_DIR.tar.gz
-TARBALL_URL=https://download.libsodium.org/libsodium/releases/$TARBALL
+TARBALL_URL=https://download.libsodium.org/libsodium/releases/libsodium-1.0.17.tar.gz
 
 ### Paths
 


### PR DESCRIPTION
* Gets rid of silly version format for building out a URL
* Fetches a version that actually exists on the freaking host 